### PR TITLE
Check for custom mxa_manager IP address env

### DIFF
--- a/frigate/detectors/plugins/memryx.py
+++ b/frigate/detectors/plugins/memryx.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "memryx"
 
+# Check if custom environment variable is set for mxa_manager IP otherwise
+# fall back to 'gateway.docker.internal'
+mxserver_addr = os.getenv('MXA_MANAGER_ADDRESS', 'gateway.docker.internal')
+
 # Configuration class for model settings
 class ModelConfig(BaseModel):
     path: str = Field(default=None, title="Model Path")  # Path to the DFP file
@@ -129,7 +133,7 @@ class MemryXDetector(DetectionApi):
             # Load MemryX Model with a unique device target
             self.accl = AsyncAccl(
                 self.memx_model_path,
-                mxserver_addr="gateway.docker.internal",
+                mxserver_addr=mxserver_addr,
                 group_id=device_id,  # AsyncAccl device id
             )
 


### PR DESCRIPTION
## Proposed change
This makes it possible to define a variable named `MXA_MANAGER_ADDRESS` which will override `gateway.docker.internal` if found, otherwise it will fall back to `gateway.docker.internal`


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to discussion [#1](https://github.com/memryx/MemryX_eXamples/discussions/1) & [#2](https://github.com/memryx/MemryX_eXamples/discussions/2)

## Checklist

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
